### PR TITLE
[Fix] 수리점 카카오맵 오버레이 제목 줄바꿈 처리

### DIFF
--- a/src/pages/repair/model/useRepairMap.ts
+++ b/src/pages/repair/model/useRepairMap.ts
@@ -15,7 +15,7 @@ const buildOverlayContent = (shop: RepairShop) => {
   return `
     <div style="position:relative; transform:translateY(-8px);">
       <div style="padding:var(--padding-m) var(--spacing-s); font-size:12px; line-height:1.4; width:260px; background:var(--color-green-100); border-radius:var(--radius-m); border:2px solid var(--color-green-700); box-shadow:0 8px 20px rgba(17,203,176,0.18);">
-        <div style="font-weight:700; margin-bottom:var(--spacing-xxxxs); word-break:break-word; color:var(--color-green-900);">${shop.name}</div>
+        <div style="font-weight:700; margin-bottom:var(--spacing-xxxxs); word-break:break-word; overflow-wrap:anywhere; color:var(--color-green-900); white-space:normal;">${shop.name}</div>
         <div style="color:var(--color-green-800); margin-bottom:4px; word-break:break-word;">${shop.address}</div>
         ${phoneDisplay ? `<div style="color:var(--color-green-800); margin-bottom:6px; word-break:break-word;">${phoneDisplay}</div>` : '<div style="margin-bottom:6px;"></div>'}
         <div style="color:var(--color-green-900); font-weight:600; word-break:keep-all;">${actions}</div>


### PR DESCRIPTION
## ✨ 주요 변경사항

수리점 이름이 길어질 시 오버레이를 튀어나왔는데 줄바꿈 처리했습니다.

---

## 📝 작업 상세 내용

수리점 이름이 길어질 시 오버레이를 튀어나왔는데 줄바꿈 처리했습니다.

---

## ✅ 체크리스트

- [x] PR 본문에 `Close #번호` 추가
- [x] 불필요한 주석, 디버깅 코드 제거
- [x] 기능 테스트 및 정상 동작 확인
- [x] 커밋컨벤션 / 코드컨벤션 준수

---

## 📸 스크린샷 (선택)

- 이전
<img width="309" height="135" alt="스크린샷 2026-02-12 오후 4 43 43" src="https://github.com/user-attachments/assets/72c606c1-58d5-481e-b09d-2b3cb9ac0d9c" />

- 이후
<img width="1269" height="865" alt="스크린샷 2026-02-12 오후 4 43 19" src="https://github.com/user-attachments/assets/132a9b4b-0cda-4f19-adeb-d952cbeb3d7d" />


---

## 🔍 기타 참고사항


---

## 🔗 관련 이슈


- Close #108 
